### PR TITLE
fix missed version filamentphp 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "~8.2.0|~8.3|~8.4|~8.5",
         "spatie/laravel-package-tools": "^1.13.5",
-        "filament/filament": "^4",
+        "filament/filament": ">=4.0"
         "ariaieboy/jalali": "^1.0.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "~8.2.0|~8.3|~8.4|~8.5",
         "spatie/laravel-package-tools": "^1.13.5",
-        "filament/filament": ">=4.0"
+        "filament/filament": ">=4.0",
         "ariaieboy/jalali": "^1.0.1"
     },
     "require-dev": {


### PR DESCRIPTION
Fix: Add support for Filament 5 and update description

- Updated composer.json to allow "filament/filament": ">=4.0"
  so the package works with Filament 4 and 5.
- Updated package description to: "Add Jalali/Shamsi support for FilamentPHP 4 and 5"